### PR TITLE
Add to view controller to container before transition

### DIFF
--- a/UIKit/View Controller Transitions/TWTSimpleAnimationController.m
+++ b/UIKit/View Controller Transitions/TWTSimpleAnimationController.m
@@ -61,11 +61,20 @@
     toViewController.view.frame = [transitionContext finalFrameForViewController:toViewController];
     [toViewController.view layoutIfNeeded];
 
+    BOOL optionsContainShowHideTransitionViews = (self.options & UIViewAnimationOptionShowHideTransitionViews) != 0;
+    if (!optionsContainShowHideTransitionViews) {
+        [[transitionContext containerView] addSubview:toViewController.view];
+    }
+
     [UIView transitionFromView:fromViewController.view
                         toView:toViewController.view
                       duration:self.duration
-                       options:self.options
+                       options:self.options | UIViewAnimationOptionShowHideTransitionViews
                     completion:^(BOOL finished) {
+                        if (!optionsContainShowHideTransitionViews) {
+                            [fromViewController.view removeFromSuperview];
+                        }
+
                         [transitionContext completeTransition:YES];
                     }];
 }


### PR DESCRIPTION
This solves the problem where a view might not inherit a tint color until after the transition is complete
